### PR TITLE
TCP stuff and Respond with CONNACKs

### DIFF
--- a/apps/broker/lib/broker.ex
+++ b/apps/broker/lib/broker.ex
@@ -1,18 +1,43 @@
 defmodule Broker do
-  @moduledoc """
-  Documentation for Broker.
-  """
+  require Logger
 
-  @doc """
-  Hello world.
+  def accept(port) do
+    {:ok, socket} =
+      :gen_tcp.listen(port, [:binary, packet: :line, active: false, reuseaddr: true])
 
-  ## Examples
+    Logger.info("Accepting connections on port #{port}")
+    loop_acceptor(socket)
+  end
 
-      iex> Broker.hello()
-      :world
+  defp loop_acceptor(socket) do
+    {:ok, client} = :gen_tcp.accept(socket)
 
-  """
-  def hello do
-    :world
+    {:ok, pid} = Task.Supervisor.start_child(Broker.TaskSupervisor, fn -> serve(client) end)
+    :ok = :gen_tcp.controlling_process(client, pid)
+
+    loop_acceptor(socket)
+  end
+
+  defp serve(socket) do
+    msg = read_line(socket)
+
+    Logger.info("Received: stuff")
+    Logger.info("Received: #{msg}")
+
+    write_line(socket, msg)
+    serve(socket)
+  end
+
+  defp read_line(socket) do
+    :gen_tcp.recv(socket, 0)
+  end
+
+  defp write_line(socket, {:ok, text}) do
+    :gen_tcp.send(socket, text)
+  end
+
+  defp write_line(socket, {:error, error}) do
+    :gen_tcp.send(socket, "ERROR\r\n")
+    exit(error)
   end
 end

--- a/apps/broker/lib/broker.ex
+++ b/apps/broker/lib/broker.ex
@@ -2,8 +2,7 @@ defmodule Broker do
   require Logger
 
   def accept(port) do
-    {:ok, socket} =
-      :gen_tcp.listen(port, [:binary, packet: :line, active: false, reuseaddr: true])
+    {:ok, socket} = :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true])
 
     Logger.info("Accepting connections on port #{port}")
     loop_acceptor(socket)
@@ -21,8 +20,8 @@ defmodule Broker do
   defp serve(socket) do
     msg = read_line(socket)
 
-    Logger.info("Received: stuff")
-    Logger.info("Received: #{msg}")
+    packet = elem(msg, 1)
+    Logger.info("Received: #{elem(msg, 0)}, #{packet}")
 
     write_line(socket, msg)
     serve(socket)
@@ -32,8 +31,11 @@ defmodule Broker do
     :gen_tcp.recv(socket, 0)
   end
 
-  defp write_line(socket, {:ok, text}) do
-    :gen_tcp.send(socket, text)
+  defp write_line(socket, {:ok, _}) do
+    connack = <<32, 2, 0, 0>>
+    Logger.info("Sending: #{connack}")
+
+    :gen_tcp.send(socket, connack)
   end
 
   defp write_line(socket, {:error, error}) do

--- a/apps/broker/lib/broker/application.ex
+++ b/apps/broker/lib/broker/application.ex
@@ -1,0 +1,17 @@
+defmodule Broker.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    port = String.to_integer(System.get_env("PORT") || "1883")
+
+    children = [
+      {Task.Supervisor, name: Broker.TaskSupervisor},
+      Supervisor.child_spec({Task, fn -> Broker.accept(port) end}, restart: :permanent)
+    ]
+
+    opts = [strategy: :one_for_one, name: Broker.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/broker/mix.exs
+++ b/apps/broker/mix.exs
@@ -18,7 +18,8 @@ defmodule Broker.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Broker.Application, []}
     ]
   end
 

--- a/apps/broker/test/broker_test.exs
+++ b/apps/broker/test/broker_test.exs
@@ -1,8 +1,4 @@
 defmodule BrokerTest do
   use ExUnit.Case
   doctest Broker
-
-  test "greets the world" do
-    assert Broker.hello() == :world
-  end
 end

--- a/apps/broker/test/broker_test.exs
+++ b/apps/broker/test/broker_test.exs
@@ -1,4 +1,27 @@
 defmodule BrokerTest do
   use ExUnit.Case
-  doctest Broker
+
+  setup do
+    Application.stop(:broker)
+    :ok = Application.start(:broker)
+  end
+
+  setup do
+    opts = [:binary, active: false]
+    {:ok, socket} = :gen_tcp.connect('localhost', 1883, opts)
+    %{socket: socket}
+  end
+
+  test "CONNECT returns a CONNACK", %{socket: socket} do
+    connect = <<12>>
+    connack = <<32, 2, 0, 0>>
+
+    assert send_and_recv(socket, connect) == connack
+  end
+
+  defp send_and_recv(socket, packet) do
+    :ok = :gen_tcp.send(socket, packet)
+    {:ok, data} = :gen_tcp.recv(socket, 0, 1000)
+    data
+  end
 end


### PR DESCRIPTION
Learned some things:
- The reason we didn't see anything incoming from the mosquitto client is that in `:gen_tcp.listen` we were giving the option `packet: :line`
- CONNACK is four bytes. I'm 70% sure I understand what's going on past the first two bytes, but: the format is `[control packet type and flags, remaining length in bytes, property length (zero), reason code]`
  - first two bytes constitute the "Fixed Header"
  - remaining length byte is part of the "Variable Header"
  - CONNACK has no "Payload", the third possible part of any MQTT control packet
  - fourth byte is the "Reason Code". Zeros are good, apparently

reference: http://docs.oasis-open.org/mqtt/mqtt/v5.0/cs01/mqtt-v5.0-cs01.pdf pg 21