### PR TITLE
Added parser for CONNECT packet data

### DIFF
--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -22,17 +22,19 @@ defmodule Broker.Packet do
       <<_::9*8, connect_flags, _::binary>> when connect_flags != 2 and connect_flags != 1 ->
         {:not_implemented_connect, "only currently handling client id in CONNECT payload"}
 
-      <<_, remaining_length, 0, 4, "M", "Q", "T", "T", protocol_level, connect_flags,
-        keep_alive::16, client_id_length::16, client_id::binary>> ->
+      <<_, _, 0, 4, "M", "Q", "T", "T", protocol_level, connect_flags,
+        keep_alive::16, client_id_length::16, client_id::binary>> when client_id_length == byte_size(client_id)->
         {:connect,
          %{
            :client_id => client_id,
            :connect_flags => connect_flags,
-           :keep_alive => keep_alive
+           :keep_alive => keep_alive,
+           :protocol_level => protocol_level
          }}
 
       _ ->
         {:error, "could not parse CONNECT"}
     end
   end
+
 end

--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -1,0 +1,38 @@
+defmodule Broker.Packet do
+  require Logger
+
+  def parse(msg) do
+    case msg do
+      <<1::4, _::4, _::binary>> -> parse_connect(msg)
+      _ -> {:error, "could not determine packet type"}
+    end
+  end
+
+  defp parse_connect(msg) do
+    case msg do
+      <<_, remaining_length, _::binary>> when remaining_length > 127 ->
+        {:not_implemented_connect, "can't handle >127 remaining lengths"}
+
+      <<_, remaining_length, rest::binary>> when byte_size(rest) != remaining_length ->
+        {:error, "remaining length is wrong"}
+
+      <<_, _, protocol_length::16, protocol::64, _::binary>> when protocol_length != 4 ->
+        {:not_implemented_connect, "protocol length bad: only supporting MQTT (size 4)"}
+
+      <<_::9*8, connect_flags, _::binary>> when connect_flags != 2 and connect_flags != 1 ->
+        {:not_implemented_connect, "only currently handling client id in CONNECT payload"}
+
+      <<_, remaining_length, 0, 4, "M", "Q", "T", "T", protocol_level, connect_flags,
+        keep_alive::16, client_id_length::16, client_id::binary>> ->
+        {:connect,
+         %{
+           :client_id => client_id,
+           :connect_flags => connect_flags,
+           :keep_alive => keep_alive
+         }}
+
+      _ ->
+        {:error, "could not parse CONNECT"}
+    end
+  end
+end

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -14,6 +14,7 @@ defmodule Broker.PacketTest do
     assert data[:client_id] == "hello world"
     assert data[:connect_flags] == 2
     assert data[:keep_alive] == 60
+    assert data[:protocol_level] == 4
   end
 
   test "returns error when cant parse CONNECT" do

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -1,0 +1,26 @@
+defmodule Broker.PacketTest do
+  use ExUnit.Case
+
+  test "returns error for unrecognized message types" do
+    {result, _} = Broker.Packet.parse(<<0, 2, 0, 0>>)
+    assert result == :error
+  end
+
+  test "parses CONNECT" do
+    connect = <<16, 23, 0, 4, ?M, ?Q, ?T, ?T, 4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l, ?d>>
+    {result, data} = Broker.Packet.parse(connect)
+
+    assert result == :connect
+    assert data[:client_id] == "hello world"
+    assert data[:connect_flags] == 2
+    assert data[:keep_alive] == 60
+  end
+
+  test "returns error when cant parse CONNECT" do
+    connect_with_bad_protocol = <<16, 23, 0, 4, ?H, ?T, ?T, ?P, 4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l, ?d>>
+
+    {result, msg} = Broker.Packet.parse(connect_with_bad_protocol)
+    assert result == :error
+    assert msg == "could not parse CONNECT"
+  end
+end

--- a/apps/broker/test/broker_test.exs
+++ b/apps/broker/test/broker_test.exs
@@ -13,10 +13,16 @@ defmodule BrokerTest do
   end
 
   test "CONNECT returns a CONNACK", %{socket: socket} do
-    connect = <<12>>
-    connack = <<32, 2, 0, 0>>
+    connect = <<16, 23, 0, 4, ?M, ?Q, ?T, ?T, ?4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l, ?d>>
 
-    assert send_and_recv(socket, connect) == connack
+    assert send_and_recv(socket, connect) == <<32, 2, 0, 0>>
+  end
+
+  test "CONNACKs with error code when bad CONNECT is sent", %{socket: socket} do
+    wrong_remaining_length = <<16, 0, 0, 0>>
+
+    <<32, 2, 0, reason_code>> = send_and_recv(socket, wrong_remaining_length)
+    assert reason_code != 0
   end
 
   defp send_and_recv(socket, packet) do


### PR DESCRIPTION
Currently parsing out client id, connect flags, and keep alive time from CONNECT packets. 

Not doing some things like parsing Variable Byte Integers, so did some checking and returned :not_implemented_connect from the parser, random CONNACK error code to the client.

[Here](https://www.digi.com/resources/documentation/digidocs/90001525/reference/r_example_mqtt.htm) is a super helpful illustration of a simple CONNECT.

Some things not handled in parsing of CONNECT:
- `remaining length` > 1 byte
- `protocol length` and `protocol name` when not 4 and "MQTT". Not sure if that's important. However, the nginx example had length 6 and "MQ--some weird characters--"
- I don't know why examples often have `protocol level` at 4, instead of 3 or 5
- `connect flags`, pretty much at all. `clean start` is settable, but all other flags are rejected, because they signal that there are more things to parse in the payload, which is hard work
- checking of `client id length`

Feedback on the parsing implementation super welcome