### PR TITLE
Mqtt 3 -> 5

### DIFF
--- a/apps/broker/lib/broker/connection.ex
+++ b/apps/broker/lib/broker/connection.ex
@@ -71,7 +71,7 @@ defmodule Broker.Connection do
   defp handle(socket, {:subscribe, packet}) do
     Logger.info("received SUBSCRIBE to #{packet[:topic_filter]}, sending SUBACK")
 
-    suback = <<144, 4, packet[:packet_id]::16, 0>>
+    suback = <<144, 3, packet[:packet_id]::16, 0>>
     :gen_tcp.send(socket, suback)
   end
 

--- a/apps/broker/lib/broker/connection.ex
+++ b/apps/broker/lib/broker/connection.ex
@@ -68,10 +68,10 @@ defmodule Broker.Connection do
     :gen_tcp.send(socket, impl_specific_error_connack)
   end
 
-  defp handle(socket, {:subscribe, _}) do
-    Logger.info("received SUBSCRIBE, sending SUBACK")
+  defp handle(socket, {:subscribe, packet}) do
+    Logger.info("received SUBSCRIBE to #{packet[:topic_filter]}, sending SUBACK")
 
-    suback = <<144, 4, 3, 31, ?h, ?i>>
+    suback = <<144, 4, packet[:packet_id]::16, 0>>
     :gen_tcp.send(socket, suback)
   end
 

--- a/apps/broker/lib/broker/connection.ex
+++ b/apps/broker/lib/broker/connection.ex
@@ -50,9 +50,13 @@ defmodule Broker.Connection do
   defp handle(socket, {:connect, data}) do
     Broker.Connection.Registry.register(Broker.Connection.Registry, data[:client_id], self())
 
-    Logger.info("received CONNECT from client id: #{data[:client_id]}, protocol level #{data[:protocol_level]}. Sending CONNACK")
+    Logger.info(
+      "received CONNECT from client id: #{data[:client_id]}, protocol level #{
+        data[:protocol_level]
+      }. Sending CONNACK"
+    )
 
-    connack = <<32, 2, 0, 0>>
+    connack = <<32, 3, 0, 0, 0>>
     :gen_tcp.send(socket, connack)
   end
 

--- a/apps/broker/lib/broker/connection.ex
+++ b/apps/broker/lib/broker/connection.ex
@@ -42,11 +42,6 @@ defmodule Broker.Connection do
     {:reply, :ok, {socket}}
   end
 
-  defp handle(_, {:error, :closed}) do
-    Logger.info("connection close, shutting down")
-    exit(:shutdown)
-  end
-
   defp handle(socket, {:connect, data}) do
     Broker.Connection.Registry.register(Broker.Connection.Registry, data[:client_id], self())
 
@@ -58,14 +53,6 @@ defmodule Broker.Connection do
 
     connack = <<32, 3, 0, 0, 0>>
     :gen_tcp.send(socket, connack)
-  end
-
-  defp handle(socket, {:not_implemented_connect, msg}) do
-    Logger.info("received CONNECT with unimplemented options: #{msg}")
-
-    #    haven't figured out how to send the right error code, but sending any causes the client to properly disconnect
-    impl_specific_error_connack = <<32, 2, 0, 131>>
-    :gen_tcp.send(socket, impl_specific_error_connack)
   end
 
   defp handle(socket, {:subscribe, packet}) do

--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -37,15 +37,16 @@ defmodule Broker.Packet do
   defp parse_subscribe(msg) do
     <<_, rest::binary>> = msg
     <<_remaining_length, rest::binary>> = rest
-    <<_packet_id::16, rest::binary>> = rest
+    <<packet_id::16, rest::binary>> = rest
+    <<properties_length, rest::binary>> = rest
+    <<_properties::binary-size(properties_length), rest::binary>> = rest
     <<topic_filter_length::16, rest::binary>> = rest
-    <<topic::binary-size(topic_filter_length), rest::binary>> = rest
-
-    Logger.info("SUBSCRIBE info: #{topic_filter_length}")
+    <<topic_filter::binary-size(topic_filter_length), rest::binary>> = rest
 
     {:subscribe,
      %{
-       :topic => topic
+       :topic_filter => topic_filter,
+       :packet_id => packet_id
      }}
   end
 

--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -74,16 +74,16 @@ defmodule Broker.Packet do
       raise "error parsing variable length int: encountered more than 4 bytes"
     end
 
-    <<more_bytes?::1, x::7, rest::binary>> = bytes
+    <<more_bytes?::1, current_byte_value::7, rest::binary>> = bytes
     multiplier = :math.pow(128, level)
 
     case more_bytes? do
       0 ->
-        {x * multiplier, rest}
+        {current_byte_value * multiplier, rest}
 
       1 ->
-        {y, rest} = parse_variable_int(rest, level + 1)
-        {x * multiplier + y, rest}
+        {other_bytes_value, rest} = parse_variable_int(rest, level + 1)
+        {current_byte_value * multiplier + other_bytes_value, rest}
     end
   end
 end

--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -3,7 +3,7 @@ defmodule Broker.Packet do
 
   def parse(msg) do
     case msg do
-      <<1::4, _::4, _::binary>> -> parse_connect(msg)
+      <<1::4, 0::4, _::binary>> -> parse_connect(msg)
       <<3::4, _::4, _::binary>> -> parse_publish(msg)
       <<8::4, 2::4, _::binary>> -> parse_subscribe(msg)
       _ -> {:error, "could not determine packet type"}
@@ -11,33 +11,27 @@ defmodule Broker.Packet do
   end
 
   defp parse_connect(msg) do
-    case msg do
-      <<_, remaining_length, _::binary>> when remaining_length > 127 ->
-        {:not_implemented_connect, "can't handle >127 remaining lengths"}
+    <<_packet_type, rest::binary>> = msg
+    <<_remaining_length, rest::binary>> = rest
 
-      <<_, remaining_length, rest::binary>> when byte_size(rest) != remaining_length ->
-        {:error, "remaining length is wrong"}
+    <<protocol_length::16, rest::binary>> = rest
+    <<protocol::binary-size(protocol_length), rest::binary>> = rest
+    <<protocol_level, rest::binary>> = rest
+    <<connect_flags, rest::binary>> = rest
+    <<keep_alive::16, rest::binary>> = rest
+    <<props_length, rest::binary>> = rest
+    <<_properties::binary-size(props_length), rest::binary>> = rest
 
-      <<_, _, protocol_length::16, _::binary>> when protocol_length != 4 ->
-        {:not_implemented_connect, "protocol length bad: only supporting MQTT (size 4)"}
+    <<client_id_length::16, rest::binary>> = rest
+    <<client_id::binary-size(client_id_length)>> = rest
 
-      <<_::9*8, connect_flags, _::binary>> when connect_flags != 2 and connect_flags != 1 ->
-        {:not_implemented_connect, "only currently handling client id in CONNECT payload"}
-
-      <<_, _, 0, 4, "M", "Q", "T", "T", protocol_level, connect_flags, keep_alive::16,
-        client_id_length::16, client_id::binary>>
-      when client_id_length == byte_size(client_id) ->
-        {:connect,
-         %{
-           :client_id => client_id,
-           :connect_flags => connect_flags,
-           :keep_alive => keep_alive,
-           :protocol_level => protocol_level
-         }}
-
-      _ ->
-        {:error, "could not parse CONNECT"}
-    end
+    {:connect,
+     %{
+       :client_id => client_id,
+       :connect_flags => connect_flags,
+       :keep_alive => keep_alive,
+       :protocol_level => protocol_level
+     }}
   end
 
   defp parse_subscribe(msg) do
@@ -50,10 +44,9 @@ defmodule Broker.Packet do
     Logger.info("SUBSCRIBE info: #{topic_filter_length}")
 
     {:subscribe,
-      %{
+     %{
        :topic => topic
-       }
-    }
+     }}
   end
 
   defp parse_publish(msg) do

--- a/apps/broker/lib/broker/packet.ex
+++ b/apps/broker/lib/broker/packet.ex
@@ -71,7 +71,7 @@ defmodule Broker.Packet do
 
   defp parse_variable_int(bytes, level) do
     if level > 3 do
-      raise "error parsing varible length int: encountered more than 4 bytes"
+      raise "error parsing variable length int: encountered more than 4 bytes"
     end
 
     <<more_bytes?::1, x::7, rest::binary>> = bytes

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -59,10 +59,11 @@ defmodule Broker.PacketTest do
     assert Broker.Packet.parse_variable_int(<<255, 255, 255, 127, 0>>) == {268_435_455, <<0>>}
   end
 
+  #  test "parsing varible length ints returns binary "
+
   test "max variable length bytes is 4" do
     assert_raise RuntimeError, ~r/error/, fn ->
       Broker.Packet.parse_variable_int(<<255, 255, 255, 255, 7>>)
     end
   end
-
 end

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -59,8 +59,6 @@ defmodule Broker.PacketTest do
     assert Broker.Packet.parse_variable_int(<<255, 255, 255, 127, 0>>) == {268_435_455, <<0>>}
   end
 
-  #  test "parsing varible length ints returns binary "
-
   test "max variable length bytes is 4" do
     assert_raise RuntimeError, ~r/error/, fn ->
       Broker.Packet.parse_variable_int(<<255, 255, 255, 255, 7>>)

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -21,11 +21,13 @@ defmodule Broker.PacketTest do
   end
 
   test "parses SUBSCRIBE" do
-    subscribe = <<130, 14, 0, 0, 0, 9, ?t, ?e, ?s, ?t, ?T, ?o, ?p, ?i, ?c, 0>>
+    packet_id = 123
+    subscribe = <<130, 14, packet_id::16, 0, 0, 9, ?t, ?e, ?s, ?t, ?T, ?o, ?p, ?i, ?c, 0>>
     {result, packet} = Broker.Packet.parse(subscribe)
 
     assert result == :subscribe
-    assert packet[:topic] == "testTopic"
+    assert packet[:topic_filter] == "testTopic"
+    assert packet[:packet_id] == packet_id
   end
 
   test "parses PUBLISH" do

--- a/apps/broker/test/broker/packet_test.exs
+++ b/apps/broker/test/broker/packet_test.exs
@@ -8,8 +8,8 @@ defmodule Broker.PacketTest do
 
   test "parses CONNECT" do
     connect =
-      <<16, 23, 0, 4, ?M, ?Q, ?T, ?T, 4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l,
-        ?d>>
+      <<16, 24, 0, 4, ?M, ?Q, ?T, ?T, 5, 2, 0, 60, 0, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r,
+        ?l, ?d>>
 
     {result, data} = Broker.Packet.parse(connect)
 
@@ -17,17 +17,7 @@ defmodule Broker.PacketTest do
     assert data[:client_id] == "hello world"
     assert data[:connect_flags] == 2
     assert data[:keep_alive] == 60
-    assert data[:protocol_level] == 4
-  end
-
-  test "returns error when cant parse CONNECT" do
-    connect_with_bad_protocol =
-      <<16, 23, 0, 4, ?H, ?T, ?T, ?P, 4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l,
-        ?d>>
-
-    {result, msg} = Broker.Packet.parse(connect_with_bad_protocol)
-    assert result == :error
-    assert msg == "could not parse CONNECT"
+    assert data[:protocol_level] == 5
   end
 
   test "parses SUBSCRIBE" do

--- a/apps/broker/test/broker_test.exs
+++ b/apps/broker/test/broker_test.exs
@@ -14,19 +14,20 @@ defmodule BrokerTest do
 
   test "SUBSCRIBE flow", %{socket: socket} do
     connect =
-      <<16, 23, 0, 4, ?M, ?Q, ?T, ?T, ?4, 2, 0, 60, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r, ?l,
-        ?d>>
+      <<16, 24, 0, 4, ?M, ?Q, ?T, ?T, 5, 2, 0, 60, 0, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r,
+        ?l, ?d>>
 
     subscribe = <<130, 14, 0, 0, 0, 9, ?t, ?e, ?s, ?t, ?T, ?o, ?p, ?i, ?c, 0>>
 
-    assert send_and_recv(socket, connect) == <<32, 2, 0, 0>>
+    assert send_and_recv(socket, connect) == <<32, 3, 0, 0, 0>>
     <<144, _::binary>> = send_and_recv(socket, subscribe)
   end
 
   test "CONNACKs with error code when bad CONNECT is sent", %{socket: socket} do
-    wrong_remaining_length = <<16, 0, 0, 0>>
+    bad_header_flags = 4
+    connect = <<1::4, bad_header_flags::4, 0, 0, 0>>
 
-    <<32, 2, 0, reason_code>> = send_and_recv(socket, wrong_remaining_length)
+    <<32, 2, 0, reason_code>> = send_and_recv(socket, connect)
     assert reason_code != 0
   end
 

--- a/apps/broker/test/broker_test.exs
+++ b/apps/broker/test/broker_test.exs
@@ -17,7 +17,8 @@ defmodule BrokerTest do
       <<16, 24, 0, 4, ?M, ?Q, ?T, ?T, 5, 2, 0, 60, 0, 0, 11, ?h, ?e, ?l, ?l, ?o, 32, ?w, ?o, ?r,
         ?l, ?d>>
 
-    subscribe = <<130, 14, 0, 0, 0, 9, ?t, ?e, ?s, ?t, ?T, ?o, ?p, ?i, ?c, 0>>
+    packet_id = 65
+    subscribe = <<130, 14, packet_id::16, 0, 0, 9, ?t, ?e, ?s, ?t, ?T, ?o, ?p, ?i, ?c, 0>>
 
     assert send_and_recv(socket, connect) == <<32, 3, 0, 0, 0>>
     <<144, _::binary>> = send_and_recv(socket, subscribe)


### PR DESCRIPTION
Turns out, when the client you're using to test actually uses mqtt v5, the spec tends to make a lot more sense. Parsing has become a lot more sane.

Also actually parsing Variable Byte Integers now. That was fun