### PR TITLE
Minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ erl_crash.dump
 .idea/
 *.iml
 
-Mnesia.nonode@nohost
+Mnesia.*@*

--- a/apps/client/lib/client.ex
+++ b/apps/client/lib/client.ex
@@ -28,7 +28,7 @@ defmodule Client do
     {:ok, <<32, 3, 0, 0, 0>>} = :gen_tcp.recv(socket, 0, 1000)
   end
 
-  defp subscribe(socket, topic_filter, qos) do
+  defp subscribe(socket, topic_filter, _qos) do
     encoded_subscribe =
       Packet.encode(%Packet.Subscribe{packet_id: 123, topics: [{topic_filter, 0}]})
 

--- a/apps/packet/lib/packet/connack.ex
+++ b/apps/packet/lib/packet/connack.ex
@@ -2,8 +2,6 @@ defmodule Packet.Connack do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @type status :: :accepted | {:refused, refusal_reasons()}
   @type refusal_reasons ::
           :unacceptable_protocol_version

--- a/apps/packet/lib/packet/disconnect.ex
+++ b/apps/packet/lib/packet/disconnect.ex
@@ -1,9 +1,7 @@
 defmodule Packet.Disconnect do
   use Bitwise
   require Logger
-
-  alias Packet.Decode
-
+  
   @opaque decode_result :: {:disconnect, String.t()}
 
   @spec decode(<<_::8>>, <<_::8>>) :: decode_result

--- a/apps/packet/lib/packet/pingreq.ex
+++ b/apps/packet/lib/packet/pingreq.ex
@@ -2,8 +2,6 @@ defmodule Packet.Pingreq do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque t :: %__MODULE__{}
 
   @opaque decode_result :: {:pingreq, t}

--- a/apps/packet/lib/packet/pingresp.ex
+++ b/apps/packet/lib/packet/pingresp.ex
@@ -2,8 +2,6 @@ defmodule Packet.Pingresp do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque t :: %__MODULE__{}
 
   @opaque decode_result :: {:pingresp, t}
@@ -17,7 +15,7 @@ defmodule Packet.Pingresp do
   end
 
   defimpl Packet.Encodable do
-    def encode(%Packet.Pingresp{} = t) do
+    def encode(%Packet.Pingresp{} = _) do
       <<13::4, 0::4, 0::8>>
     end
   end

--- a/apps/packet/lib/packet/puback.ex
+++ b/apps/packet/lib/packet/puback.ex
@@ -2,8 +2,6 @@ defmodule Packet.Puback do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @type status :: {:accepted, accept_reasons()} | {:refused, refusal_reasons()}
   @type accept_reasons ::
           :ok
@@ -38,7 +36,7 @@ defmodule Packet.Puback do
         }
       }
 
-  def decode(<<4::4, 0::4>>, <<packet_id::16, reason_code::8, property_length::8, _rest::binary>>)
+  def decode(<<4::4, 0::4>>, <<packet_id::16, reason_code::8, _property_length::8, _rest::binary>>)
       when packet_id in 0x0001..0xFFFF and
              (reason_code == 0x00 or
                 reason_code == 0x10 or
@@ -116,8 +114,5 @@ defmodule Packet.Puback do
         :payload_format_invalid -> 0x99
       end
     end
-
-    defp flag(f) when f in [0, nil, false], do: 0
-    defp flag(_), do: 1
   end
 end

--- a/apps/packet/lib/packet/pubcomp.ex
+++ b/apps/packet/lib/packet/pubcomp.ex
@@ -2,8 +2,6 @@ defmodule Packet.Pubcomp do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque decode_result :: {:pubcomp, String.t()}
 
   @spec decode(<<_::8>>, <<_::24>>) :: decode_result

--- a/apps/packet/lib/packet/pubrec.ex
+++ b/apps/packet/lib/packet/pubrec.ex
@@ -2,8 +2,6 @@ defmodule Packet.Pubrec do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque decode_result :: {:pubrec, String.t()}
 
   @spec decode(<<_::8>>, <<_::24>>) :: decode_result

--- a/apps/packet/lib/packet/pubrel.ex
+++ b/apps/packet/lib/packet/pubrel.ex
@@ -2,8 +2,6 @@ defmodule Packet.Pubrel do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque decode_result :: {:pubrel, String.t()}
 
   @spec decode(<<_::8>>, <<_::24>>) :: decode_result

--- a/apps/packet/lib/packet/subscribe.ex
+++ b/apps/packet/lib/packet/subscribe.ex
@@ -47,7 +47,7 @@ defmodule Packet.Subscribe do
     def encode(
           %Packet.Subscribe{
             packet_id: packet_id,
-            topics: [{<<_topic_filter::binary>>, qos} | _]
+            topics: [{<<_topic_filter::binary>>, _qos} | _]
           } = subscribe
         )
         when packet_id in 0x0001..0xFFFF do
@@ -69,8 +69,5 @@ defmodule Packet.Subscribe do
         <<0>> <>
         encoded_topics
     end
-
-    defp flag(f) when f in [0, nil, false], do: 0
-    defp flag(_), do: 1
   end
 end

--- a/apps/packet/lib/packet/unsuback.ex
+++ b/apps/packet/lib/packet/unsuback.ex
@@ -2,8 +2,6 @@ defmodule Packet.Unsuback do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque decode_result :: {:unsuback, String.t()}
 
   @spec decode(<<_::8>>, <<_::24>>) :: decode_result

--- a/apps/packet/lib/packet/unsubscribe.ex
+++ b/apps/packet/lib/packet/unsubscribe.ex
@@ -2,8 +2,6 @@ defmodule Packet.Unsubscribe do
   use Bitwise
   require Logger
 
-  alias Packet.Decode
-
   @opaque decode_result :: {:unsubscribe, String.t()}
 
   @spec decode(<<_::8>>, binary()) :: decode_result


### PR DESCRIPTION
Thought I would find more unused things to kill. `Connection.Registry.get_pid` isn't used anymore since that's no longer the place to find connection pids, but it's currently kinda useful for testing